### PR TITLE
Canvas Rich Content Editor API via Passenger

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,12 @@
+turnkey-canvas-15.3 (1) turnkey; urgency=low
+
+  * Install latest Canvas LTS stable from upstream git repo.
+
+  * Include Canvas RCE API service run with Passenger.
+
+ -- Zhenya Hvorostian <zhenya@turnkeylinux.org>  Sun, 05 May 2019 18:38:42 +0300
+
+
 turnkey-canvas-15.2 (1) turnkey; urgency=low
 
   * Install latest Canvas LTS stable from upstream git repo.

--- a/conf.d/15node
+++ b/conf.d/15node
@@ -3,5 +3,5 @@
 source /usr/local/src/canvas.conf
 
 ln -s /usr/bin/nodejs /usr/bin/node
-n 8.12.0
+n 10.15.3
 npm install node-gyp-install && ./node_modules/node-gyp-install/bin.js

--- a/conf.d/52canvas-configs
+++ b/conf.d/52canvas-configs
@@ -71,6 +71,18 @@ default:
   - queue: canvas_queue
 EOF
 
+# Canvas Rich Content Editor API
+cat >$WEBROOT/config/dynamic_settings.yml<<EOF
+production:
+  config:
+    canvas:
+      canvas:
+        encryption-secret: "turnkey1"
+        signing-secret: "turnkey1"
+      rich-content-service:
+        app-host: "canvas-rce-api-host"
+EOF
+
 # copy example configurations
 CONFIGS="amazon_s3 file_store security external_migration"
 for c in $CONFIGS; do

--- a/conf.d/53canvas-rce
+++ b/conf.d/53canvas-rce
@@ -7,6 +7,6 @@ cp .env.example .env
 
 
 sed -i "s|^PORT=.*|PORT=3000|" .env
-sed -i "s|NODE_ENV=.*|NODE_ENV=production" .env
+sed -i "s|NODE_ENV=.*|NODE_ENV=production|" .env
 
 a2ensite canvas-rce-api

--- a/conf.d/53canvas-rce
+++ b/conf.d/53canvas-rce
@@ -1,0 +1,12 @@
+git clone --depth=1 https://github.com/instructure/canvas-rce-api.git /var/www/canvas-rce-api
+
+cd /var/www/canvas-rce-api
+
+npm i --production
+cp .env.example .env
+
+
+sed -i "s|^PORT=.*|PORT=3000|" .env
+sed -i "s|NODE_ENV=.*|NODE_ENV=production" .env
+
+a2ensite canvas-rce-api

--- a/conf.d/54canvas-install
+++ b/conf.d/54canvas-install
@@ -10,7 +10,6 @@ export CANVAS_LMS_STATS_COLLECTION="opt-out"
 
 # install canvas, populate database and compile assets
 service redis-server start
-
 [ "$FAB_HTTP_PROXY" ] && export HTTP_PROXY=$FAB_HTTP_PROXY
 
 cd $WEBROOT

--- a/overlay/etc/apache2/sites-available/canvas-rce-api.conf
+++ b/overlay/etc/apache2/sites-available/canvas-rce-api.conf
@@ -1,0 +1,12 @@
+Listen 3000
+
+<VirtualHost *:3000>
+   ServerName localhost
+   SSLProxyEngine on 
+   SSLEngine on
+   SSLCertificateFile /etc/ssl/private/cert.pem
+   PassengerAppRoot /var/www/canvas-rce-api
+   PassengerAppType node
+   PassengerStartupFile app.js
+</VirtualHost>
+

--- a/overlay/usr/lib/inithooks/firstboot.d/40canvas
+++ b/overlay/usr/lib/inithooks/firstboot.d/40canvas
@@ -6,6 +6,21 @@
 [ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
 $INITHOOKS_PATH/bin/canvas.py --pass="$APP_PASS" --email="$APP_EMAIL" --domain="$APP_DOMAIN"
 
+# Canvas Rich Content Editor API keys
+ENV_FILE=/var/www/canvas-rce-api/.env
+DYNAMIC_SETTINGS=/var/www/canvas/config/dynamic_settings.yml
+
+SECRET=$(mcookie)$(mcookie)$(mcookie)
+KEY=$(mcookie)$(mcookie)$(mcookie)
+
+
+
+sed -i "s|ECOSYSTEM_KEY=.*|ECOSYSTEM_KEY=\"$KEY\"|" $ENV_FILE 
+sed -i "s|ECOSYSTEM=SECRET=.*|ECOSYSTEM_SECRET=\"$SECRET\"|" $ENV_FILE
+sed -i "s|CIPHER_PASSWORD=.*"|CIPHER_PASSWORD=\"$(mcookie)\"|" $ENV_FILE
+sed -i "s|signing-secret: .*|signing-secret: "$KEY"|" $DYNAMIC_SETTINGS
+sed -i "s|encryption-secret: .*|encryption-secret: "$SECRET"|" $DYNAMIC_SETTINGS
+
 service canvas_init restart
 
 service passenger restart

--- a/overlay/usr/lib/inithooks/firstboot.d/40canvas
+++ b/overlay/usr/lib/inithooks/firstboot.d/40canvas
@@ -16,7 +16,7 @@ KEY=$(mcookie)$(mcookie)$(mcookie)
 
 
 sed -i "s|ECOSYSTEM_KEY=.*|ECOSYSTEM_KEY=\"$KEY\"|" $ENV_FILE 
-sed -i "s|ECOSYSTEM=SECRET=.*|ECOSYSTEM_SECRET=\"$SECRET\"|" $ENV_FILE
+sed -i "s|ECOSYSTEM_SECRET=.*|ECOSYSTEM_SECRET=\"$SECRET\"|" $ENV_FILE
 sed -i "s|CIPHER_PASSWORD=.*"|CIPHER_PASSWORD=\"$(mcookie)\"|" $ENV_FILE
 sed -i "s|signing-secret: .*|signing-secret: "$KEY"|" $DYNAMIC_SETTINGS
 sed -i "s|encryption-secret: .*|encryption-secret: "$SECRET"|" $DYNAMIC_SETTINGS


### PR DESCRIPTION
Not sure if the setting to use this is enabled in stable builds by now, but in order to use this now one would need to run are:

```
$ cd /var/www/canvas
$ RAILS_ENV=production bundle exec rails c
irb:001> Setting.set('rich_content_service_enabled', 'true')
```