### PR TITLE
Rename ruby env var RBY_VER -> RUBY_VER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 WEBMIN_FW_TCP_INCOMING = 22 80 443 3000 12320 12321
 
-RBY_VER=3.1.4
+RUBY_VER=3.1.4
 include $(FAB_PATH)/common/mk/turnkey/rails-pgsql.mk
 include $(FAB_PATH)/common/mk/turnkey/nodejs.mk
 include $(FAB_PATH)/common/mk/turnkey.mk


### PR DESCRIPTION
As per subject: Rename ruby env var `RBY_VER` -> `RUBY_VER`

Also requires:
- https://github.com/turnkeylinux/common/pull/298