### PR TITLE
Update bundler version as per Production Start doc

### DIFF
--- a/changelog
+++ b/changelog
@@ -5,6 +5,8 @@ turnkey-canvas-18.1 (1) turnkey; urgency=low
 
   * Update Ruby (3.1.6).
 
+  * Update bundler to 2.5.10 - as per "Production Start" doc.
+
   * Disable Apache mod_evasie for Canvas - part of #1965.
 
   * Run switchman_inst_jobs:install:migrations - closes #1965.

--- a/conf.d/55canvas-install
+++ b/conf.d/55canvas-install
@@ -26,7 +26,7 @@ cd $WEBROOT
 
 # canvas needs specific version of bundler - see
 # https://github.com/instructure/canvas-lms/wiki/Production-Start#bundler-and-canvas-dependencies
-gem install bundler --version 2.4.19
+gem install bundler --version 2.5.10
 
 # set ruby/rails vars
 export RAILS_ENV=production


### PR DESCRIPTION
I just noticed that bundler version has been updated to v2.5.10. See:

https://github.com/instructure/canvas-lms/wiki/Production-Start/#bundler-and-canvas-dependencies